### PR TITLE
Fix hard coded cluster

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -8,7 +8,7 @@
 # under /etc/ood/config/clusters.d/*.yml
 # @example Use the Owens cluster at Ohio Supercomputer Center
 #     cluster: "owens"
-cluster: "pc-dev"
+cluster: "*"
 
 # Define attribute values that aren't meant to be modified by the user within
 # the Dashboard form


### PR DESCRIPTION
Cluster was set to the value for dev, so the app won't appear for stage and prod environments without intervention. Changing to "*" allows the app to run on any cluster name.