### PR TITLE
Add config option to disable checkpoints

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -44,6 +44,12 @@ attributes:
     min: 1
     max: 4
     step: 1
+  
+  disable_checkpoints:
+    widget: "check_box"
+    label: "Disable Checkpoints"
+    help: |
+      Redirects `.ipynb_checkpoints` to `/tmp`, so checkpoints are not persistent. Select this option if you do not want checkpoint folders to appear, or if the checkpoints are causing problems.
 
   # Any extra command line arguments to feed to the `jupyter notebook ...`
   # command that launches the Jupyter notebook within the batch job
@@ -64,3 +70,4 @@ form:
   - extra_jupyter_args
   - bc_num_hours
   - custom_num_cores
+  - disable_checkpoints

--- a/form.yml
+++ b/form.yml
@@ -45,6 +45,9 @@ attributes:
     max: 4
     step: 1
   
+  # For this checkbox, a checked value is "1" as a string, and an unchecked
+  # value is "0" as a string. It's used to determine whether or not to redirect
+  # the ipynb_checkpoints folder to /tmp, functionally disabling checkpoints.
   disable_checkpoints:
     widget: "check_box"
     label: "Disable Checkpoints"

--- a/local/heb115.yml.erb
+++ b/local/heb115.yml.erb
@@ -3,6 +3,10 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
+# User POSIX groups are checked against a list of Canvas Course IDs, which are 
+# expected to be present in group names following the convention 
+# `canvas<canvas_id>-<group_id>`. To add to this list, add a Canvas Course ID 
+# and comment it with the title of the course.
 userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
 enabledGroups = [
   "135510", # HUIT Open OnDemand Testing

--- a/local/heb115.yml.erb
+++ b/local/heb115.yml.erb
@@ -3,10 +3,6 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-# User POSIX groups are checked against a list of Canvas Course IDs, which are 
-# expected to be present in group names following the convention 
-# `canvas<canvas_id>-<group_id>`. To add to this list, add a Canvas Course ID 
-# and comment it with the title of the course.
 userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
 enabledGroups = [
   "135510", # HUIT Open OnDemand Testing
@@ -63,6 +59,12 @@ attributes:
     max: 4
     step: 1
 
+  disable_checkpoints:
+    widget: "check_box"
+    label: "Disable Checkpoints"
+    help: |
+      Redirects `.ipynb_checkpoints` to `/tmp`, so checkpoints are not persistent. Select this option if you do not want checkpoint folders to appear, or if the checkpoints are causing problems.
+
   # Any extra command line arguments to feed to the `jupyter notebook ...`
   # command that launches the Jupyter notebook within the batch job
   extra_jupyter_args: ""
@@ -82,3 +84,4 @@ form:
   - extra_jupyter_args
   - bc_num_hours
   - custom_num_cores
+  - disable_checkpoints

--- a/local/heb115.yml.erb
+++ b/local/heb115.yml.erb
@@ -63,6 +63,9 @@ attributes:
     max: 4
     step: 1
 
+  # For this checkbox, a checked value is "1" as a string, and an unchecked
+  # value is "0" as a string. It's used to determine whether or not to redirect
+  # the ipynb_checkpoints folder to /tmp, functionally disabling checkpoints.
   disable_checkpoints:
     widget: "check_box"
     label: "Disable Checkpoints"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -31,6 +31,7 @@ spack find
 # Benchmark info
 echo "TIMING - Starting jupyter at: $(date)"
 
+# Parse the form variable to see if checkpoints should be redirected to /tmp
 CHECKPOINT_ARG="<%= context.disable_checkpoints=="1" ? '--FileCheckpoints.checkpoint_dir=/tmp' : '' %>"
 
 # Launch the Jupyter Lab Server

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -31,6 +31,8 @@ spack find
 # Benchmark info
 echo "TIMING - Starting jupyter at: $(date)"
 
+CHECKPOINT_ARG="<%= context.disable_checkpoints ? '--FileCheckpoints.checkpoint_dir=/tmp' : '' %>"
+
 # Launch the Jupyter Lab Server
 set -x
-jupyter lab --config="${CONFIG_FILE}" <%= context.extra_jupyter_args %>
+jupyter lab --config="${CONFIG_FILE}" $CHECKPOINT_ARG <%= context.extra_jupyter_args %>

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -31,7 +31,7 @@ spack find
 # Benchmark info
 echo "TIMING - Starting jupyter at: $(date)"
 
-CHECKPOINT_ARG="<%= context.disable_checkpoints ? '--FileCheckpoints.checkpoint_dir=/tmp' : '' %>"
+CHECKPOINT_ARG="<%= context.disable_checkpoints=="1" ? '--FileCheckpoints.checkpoint_dir=/tmp' : '' %>"
 
 # Launch the Jupyter Lab Server
 set -x


### PR DESCRIPTION
This PR adds an option to the base form.yml and the HEB 115 form.yml file to disable `.ipynb_checkpoints`, more or less. This is imprecise, since what it does is redirect the checkpoints to `/tmp`. The motivation for this PR is that a student had an issue accessing Jupyter Lab because there was a "permission denied" error on a `.ipynb_checkpoints` folder that the student could not write to.

## Context

### What are checkpoints?

I had to look this up, and found a useful [StackOverflow answer](https://stackoverflow.com/a/46422176/2344915). They're basically very simple version control, which allows you to revert to the most recent checkpoint, or manual save, for a file, even if you've been editing it and getting autosaves for a while. Despite using notebooks a lot, I've never had cause to revert to a checkpoint, or to advise someone else to do so.

Despite the fact that the checkpoints are, IMO, of limited utility, I don't want to turn off Jupyter Lab functionality on our users, in case some of them are familiar with this setup and use it in ways that I don't. That's why I prefer a checkbox that can be selected by the user to a flat out change to how Jupyter launches.

### How does this disabling work?

There is an [outstanding request](https://github.com/jupyterlab/jupyterlab/issues/11826) for Jupyter Lab to allow users to prevent the creation of the `.ipynb_checkpoints` folder and its contents, given that it can cause problems with other software. That issue points to [a different JupyterLab issue](https://github.com/jupyterlab/jupyterlab/issues/5809), which proposes a solution to the problem by setting the directory for the checkpoints to `/tmp`. This works well because `/tmp` is set to be universally writeable, but is outside of the regular home directories for users. This prevents Jupyter Lab from creating these extra folders, and ensures that the checkpoints dir is set to a writable location.

I refer to it as "disabling" the checkpoints because the checkpoints created at `/tmp` are not persistent. They will still exist for the duration of a session, probably, unless there's a file name conflict with another open file for any user on the same node. Rather than disabling them overall, it makes them very unreliable, so it's better to act like they're not there, even though you might be able to revert to a checkpoint within the same working session.

### Lingering Concern

I haven't been able to reproduce the exact behavior where not having access to the `.ipynb_checkpoints` folder prevents the app from launching. I'm including the output.log file from the student with the issue in case it's needed for reference later on.

<details>
<summary>output.log</summary>

```
Script starting...
Waiting for Jupyter Notebook server to open port 57013...
TIMING - Starting wait at: Tue Oct  8 11:58:46 EDT 2024
TIMING - Starting main script at: Tue Oct  8 11:58:46 EDT 2024
original HOME=/shared/home/kal333
user=kal333
new HOME=/shared/home/kal333
TIMING = Activated spack install
Loading environment: heb115
TIMING - Spack environment loaded at Tue Oct  8 11:59:20 EDT 2024
==> In environment heb115
==> 9 root specs
[+] admixtools@7.0.2
[+] bcftools@1.19
[+] plink@1.9-beta6.27
[+] py-jupyterlab
[+] py-matplotlib
[+] py-numpy
[+] py-pandas
[+] py-scipy
[+] samtools@1.19.2

-- linux-amzn2-skylake_avx512 / gcc@7.3.1 -----------------------
autoconf@2.72
automake@1.16.5
berkeley-db@18.1.40
bzip2@1.0.8
diffutils@3.10
findutils@4.9.0
gcc-runtime@7.3.1
gdbm@1.23
gettext@0.22.5
glibc@2.26
gmake@4.4.1
libiconv@1.17
libsigsegv@2.14
libtool@2.4.7
libxml2@2.10.3
m4@1.4.19
ncurses@6.5
perl@5.40.0
pigz@2.8
pkgconf@2.2.0
readline@8.2
tar@1.34
xz@5.4.6
zlib-ng@2.2.1
zstd@1.5.6

-- linux-amzn2-skylake_avx512 / gcc@14.1.0 ----------------------
admixtools@7.0.2
bcftools@1.19
bison@3.8.2
ca-certificates-mozilla@2023-05-30
cmake@3.30.2
curl@8.7.1
expat@2.6.2
freetype@2.13.2
gcc-runtime@14.1.0
git@2.45.2
glibc@2.26
gsl@2.7.1
gzip@1.13
htslib@1.19.1
krb5@1.21.2
libbsd@0.12.2
libdeflate@1.18
libedit@3.1-20230828
libffi@3.4.6
libidn2@2.3.7
libjpeg-turbo@3.0.3
libmd@1.0.4
libpng@1.6.39
libsodium@1.0.19
libunistring@1.2
libxcrypt@4.4.35
libyaml@0.2.5
libzmq@4.3.5
meson@1.5.1
nasm@2.15.05
nghttp2@1.62.0
ninja@1.12.0
openblas@0.3.27
openssh@9.8p1
openssl@3.3.1
pcre2@10.43
plink@1.9-beta6.27
py-anyio@4.0.0
py-argon2-cffi@21.3.0
py-argon2-cffi-bindings@21.2.0
py-arrow@1.3.0
py-asttokens@2.4.0
py-async-lru@1.0.3
py-attrs@23.1.0
py-babel@2.15.0
py-beautifulsoup4@4.12.2
py-beniget@0.4.1
py-bleach@6.0.0
py-calver@2022.6.26
py-certifi@2023.7.22
py-cffi@1.16.0
py-charset-normalizer@3.3.0
py-comm@0.1.4
py-contourpy@1.0.7
py-cppy@1.2.1
py-cycler@0.11.0
py-cython@0.29.36
py-cython@3.0.8
py-debugpy@1.6.7
py-decorator@5.1.1
py-defusedxml@0.7.1
py-editables@0.5
py-executing@1.2.0
py-fastjsonschema@2.16.3
py-flit-core@3.9.0
py-fonttools@4.39.4
py-fqdn@1.5.1
py-gast@0.5.4
py-gevent@23.7.0
py-greenlet@2.0.2
py-hatch-fancy-pypi-readme@23.1.0
py-hatch-jupyter-builder@0.8.3
py-hatch-nodejs-version@0.3.1
py-hatch-vcs@0.3.0
py-hatchling@1.21.0
py-idna@3.4
py-ipykernel@6.29.4
py-ipython@8.25.0
py-isoduration@20.11.0
py-jedi@0.18.2
py-jinja2@3.1.2
py-json5@0.9.14
py-jsonpointer@2.0
py-jsonschema@4.17.3
py-jupyter-client@8.2.0
py-jupyter-core@5.3.0
py-jupyter-events@0.6.3
py-jupyter-lsp@2.2.0
py-jupyter-server@2.6.0
py-jupyter-server-terminals@0.4.4
py-jupyterlab@4.0.1
py-jupyterlab-pygments@0.2.2
py-jupyterlab-server@2.22.1
py-kiwisolver@1.4.5
py-markupsafe@2.1.3
py-matplotlib@3.9.2
py-matplotlib-inline@0.1.6
py-meson-python@0.16.0
py-mistune@2.0.5
py-nbclient@0.8.0
py-nbconvert@7.14.1
py-nbformat@5.8.0
py-nest-asyncio@1.6.0
py-notebook-shim@0.2.3
py-numpy@1.26.4
py-overrides@7.3.1
py-packaging@23.1
py-pandas@2.0.3
py-pandocfilters@1.5.0
py-parso@0.8.3
py-pathspec@0.11.1
py-pexpect@4.8.0
py-pillow@10.4.0
py-pip@23.1.2
py-platformdirs@3.10.0
py-pluggy@1.5.0
py-ply@3.11
py-prometheus-client@0.17.0
py-prompt-toolkit@3.0.43
py-psutil@5.9.5
py-ptyprocess@0.7.0
py-pure-eval@0.2.2
py-pybind11@2.12.0
py-pycparser@2.21
py-pygments@2.18.0
py-pyparsing@3.1.2
py-pyproject-metadata@0.7.1
py-pyrsistent@0.19.3
py-pytest-runner@6.0.0
py-python-dateutil@2.8.2
py-python-json-logger@2.0.7
py-pythran@0.16.1
py-pytz@2023.3
py-pyyaml@6.0.2
py-pyzmq@25.0.2
py-requests@2.32.2
py-rfc3339-validator@0.1.4
py-rfc3986-validator@0.1.1
py-scipy@1.14.0
py-send2trash@1.8.0
py-setuptools@69.2.0
py-setuptools-scm@8.0.4
py-six@1.16.0
py-sniffio@1.3.0
py-soupsieve@2.4.1
py-stack-data@0.6.2
py-terminado@0.17.1
py-tinycss2@1.2.1
py-tomli@2.0.1
py-tornado@6.3.3
py-traitlets@5.14.3
py-trove-classifiers@2023.8.7
py-types-python-dateutil@2.8.19.14
py-typing-extensions@4.8.0
py-tzdata@2023.3
py-uri-template@1.2.0
py-urllib3@2.1.0
py-versioneer@0.29
py-wcwidth@0.2.7
py-webcolors@24.6.0
py-webencodings@0.5.1
py-websocket-client@1.6.3
py-wheel@0.41.2
py-zope-event@4.6
py-zope-interface@5.4.0
python@3.11.9
python-venv@1.0
qhull@2020.2
re2c@3.0
samtools@1.19.2
sqlite@3.46.0
util-linux-uuid@2.40.2
TIMING - Starting jupyter at: Tue Oct  8 11:59:25 EDT 2024
+ jupyter lab --config=/shared/home/kal333/ondemand/data/sys/dashboard/batch_connect/sys/ood-jupyterlab-spack/heb115/output/cc1ddcf9-0158-4585-8825-3d80c7bd6961/config.py
[I 2024-10-08 11:59:29.594 ServerApp] Package jupyterlab took 0.0000s to import
[I 2024-10-08 11:59:29.777 ServerApp] Package jupyter_lsp took 0.1828s to import
[W 2024-10-08 11:59:29.778 ServerApp] A `_jupyter_server_extension_points` function was not found in jupyter_lsp. Instead, a `_jupyter_server_extension_paths` function was found and will be used for now. This function name will be deprecated in future releases of Jupyter Server.
[I 2024-10-08 11:59:29.849 ServerApp] Package jupyter_server_terminals took 0.0707s to import
[I 2024-10-08 11:59:29.849 ServerApp] Package notebook_shim took 0.0000s to import
[W 2024-10-08 11:59:29.849 ServerApp] A `_jupyter_server_extension_points` function was not found in notebook_shim. Instead, a `_jupyter_server_extension_paths` function was found and will be used for now. This function name will be deprecated in future releases of Jupyter Server.
[I 2024-10-08 11:59:29.853 ServerApp] jupyter_lsp | extension was successfully linked.
[I 2024-10-08 11:59:29.858 ServerApp] jupyter_server_terminals | extension was successfully linked.
[W 2024-10-08 11:59:29.861 LabApp] 'ip' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2024-10-08 11:59:29.861 LabApp] 'port' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2024-10-08 11:59:29.861 LabApp] 'port_retries' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2024-10-08 11:59:29.861 LabApp] 'password' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2024-10-08 11:59:29.861 LabApp] 'base_url' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2024-10-08 11:59:29.861 LabApp] 'base_url' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2024-10-08 11:59:29.861 LabApp] 'allow_origin' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2024-10-08 11:59:29.861 LabApp] 'notebook_dir' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2024-10-08 11:59:29.861 LabApp] 'disable_check_xsrf' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2024-10-08 11:59:29.864 ServerApp] ServerApp.password config is deprecated in 2.0. Use PasswordIdentityProvider.hashed_password.
[W 2024-10-08 11:59:29.867 ServerApp] notebook_dir is deprecated, use root_dir
[I 2024-10-08 11:59:29.870 ServerApp] jupyterlab | extension was successfully linked.
[I 2024-10-08 11:59:31.166 ServerApp] notebook_shim | extension was successfully linked.
[W 2024-10-08 11:59:31.296 ServerApp] WARNING: The Jupyter server is listening on all IP addresses and not using encryption. This is not recommended.
[I 2024-10-08 11:59:31.298 ServerApp] notebook_shim | extension was successfully loaded.
[I 2024-10-08 11:59:31.299 ServerApp] jupyter_lsp | extension was successfully loaded.
[I 2024-10-08 11:59:31.300 ServerApp] jupyter_server_terminals | extension was successfully loaded.
[I 2024-10-08 11:59:31.301 LabApp] JupyterLab extension loaded from /shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyterlab
[I 2024-10-08 11:59:31.301 LabApp] JupyterLab application directory is /shared/spack/var/spack/environments/heb115/.spack-env/._view/7uqbqu5sht6m74hxd6awa4f6qzo2v6xk/share/jupyter/lab
[I 2024-10-08 11:59:31.304 LabApp] Extension Manager is 'pypi'.
[I 2024-10-08 11:59:31.307 ServerApp] jupyterlab | extension was successfully loaded.
[I 2024-10-08 11:59:31.307 ServerApp] Serving notebooks from local directory: /shared/home/kal333
[I 2024-10-08 11:59:31.307 ServerApp] Jupyter Server 2.6.0 is running at:
[I 2024-10-08 11:59:31.307 ServerApp] http://localhost:57013/node/general-dy-general-cr-2.academic.pcluster/57013/lab
[I 2024-10-08 11:59:31.307 ServerApp]     http://127.0.0.1:57013/node/general-dy-general-cr-2.academic.pcluster/57013/lab
[I 2024-10-08 11:59:31.307 ServerApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[W 2024-10-08 11:59:31.336 ServerApp] No web browser found: Error('could not locate runnable browser').
[I 2024-10-08 11:59:31.464 ServerApp] Skipped non-installed server(s): bash-language-server, dockerfile-language-server-nodejs, javascript-typescript-langserver, jedi-language-server, julia-language-server, pyright, python-language-server, python-lsp-server, r-languageserver, sql-language-server, texlab, typescript-language-server, unified-language-server, vscode-css-languageserver-bin, vscode-html-languageserver-bin, vscode-json-languageserver-bin, yaml-language-server
Discovered Jupyter Notebook server listening on port 57013!
TIMING - Wait ended at: Tue Oct  8 11:59:31 EDT 2024
Generating connection YAML file...
[I 2024-10-08 12:01:54.307 ServerApp] User 9947354d07164bb892e406f7a2a6b64f logged in.
[I 2024-10-08 12:01:54.308 ServerApp] 302 POST /node/general-dy-general-cr-2.academic.pcluster/57013/login (9947354d07164bb892e406f7a2a6b64f@10.37.33.205) 2.58ms
[I 2024-10-08 12:01:54.394 ServerApp] 302 GET /node/general-dy-general-cr-2.academic.pcluster/57013/ (@10.37.33.205) 0.42ms
[W 2024-10-08 12:01:57.399 LabApp] Could not determine jupyterlab build status without nodejs
[I 2024-10-08 12:01:58.491 ServerApp] New terminal with automatic name: 3
[W 2024-10-08 12:01:59.025 ServerApp] Notebook 139860/practical_instructions/Practical3.ipynb is not trusted
[W 2024-10-08 12:01:59.184 ServerApp] 403 GET /node/general-dy-general-cr-2.academic.pcluster/57013/api/contents/139860/practical_instructions/Practical3.ipynb/checkpoints?1728403319058 (10.37.33.205): Permission denied: 139860/practical_instructions/.ipynb_checkpoints
[W 2024-10-08 12:01:59.184 ServerApp] wrote error: 'Permission denied: 139860/practical_instructions/.ipynb_checkpoints'
    Traceback (most recent call last):
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/fileio.py", line 218, in perm_to_403
        yield
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/filecheckpoints.py", line 119, in checkpoint_path
        ensure_dir_exists(cp_dir)
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_core/utils/__init__.py", line 25, in ensure_dir_exists
        os.makedirs(path, mode=mode)
      File "<frozen os>", line 225, in makedirs
    PermissionError: [Errno 13] Permission denied: '/shared/home/kal333/139860/practical_instructions/.ipynb_checkpoints'
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/tornado/web.py", line 1786, in _execute
        result = await result
                 ^^^^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/handlers.py", line 295, in get
        checkpoints = await ensure_async(cm.list_checkpoints(path))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_core/utils/__init__.py", line 182, in ensure_async
        result = await obj
                 ^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/manager.py", line 1079, in list_checkpoints
        return await self.checkpoints.list_checkpoints(path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/filecheckpoints.py", line 195, in list_checkpoints
        os_path = self.checkpoint_path(checkpoint_id, path)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/filecheckpoints.py", line 118, in checkpoint_path
        with self.perm_to_403():
      File "/shared/spack/opt/spack/linux-amzn2-skylake_avx512/gcc-14.1.0/python-3.11.9-s6zhes3xdw6n5lx7dy2vkw55bulngxjr/lib/python3.11/contextlib.py", line 158, in __exit__
        self.gen.throw(typ, value, traceback)
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/fileio.py", line 227, in perm_to_403
        raise HTTPError(403, "Permission denied: %s" % path) from e
    tornado.web.HTTPError: HTTP 403: Forbidden (Permission denied: 139860/practical_instructions/.ipynb_checkpoints)
[W 2024-10-08 12:01:59.210 ServerApp] 403 GET /node/general-dy-general-cr-2.academic.pcluster/57013/api/contents/139860/practical_instructions/Practical3.ipynb/checkpoints?1728403319058 (9947354d07164bb892e406f7a2a6b64f@10.37.33.205) 31.33ms referer=https://ood.huit.harvard.edu/node/general-dy-general-cr-2.academic.pcluster/57013/lab
[W 2024-10-08 12:01:59.214 ServerApp] 403 GET /node/general-dy-general-cr-2.academic.pcluster/57013/api/contents/139860/practical_instructions/Practical3.ipynb/checkpoints?1728403319049 (10.37.33.205): Permission denied: 139860/practical_instructions/.ipynb_checkpoints
[W 2024-10-08 12:01:59.214 ServerApp] wrote error: 'Permission denied: 139860/practical_instructions/.ipynb_checkpoints'
    Traceback (most recent call last):
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/fileio.py", line 218, in perm_to_403
        yield
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/filecheckpoints.py", line 119, in checkpoint_path
        ensure_dir_exists(cp_dir)
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_core/utils/__init__.py", line 25, in ensure_dir_exists
        os.makedirs(path, mode=mode)
      File "<frozen os>", line 225, in makedirs
    PermissionError: [Errno 13] Permission denied: '/shared/home/kal333/139860/practical_instructions/.ipynb_checkpoints'
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/tornado/web.py", line 1786, in _execute
        result = await result
                 ^^^^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/handlers.py", line 295, in get
        checkpoints = await ensure_async(cm.list_checkpoints(path))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_core/utils/__init__.py", line 182, in ensure_async
        result = await obj
                 ^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/manager.py", line 1079, in list_checkpoints
        return await self.checkpoints.list_checkpoints(path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/filecheckpoints.py", line 195, in list_checkpoints
        os_path = self.checkpoint_path(checkpoint_id, path)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/filecheckpoints.py", line 118, in checkpoint_path
        with self.perm_to_403():
      File "/shared/spack/opt/spack/linux-amzn2-skylake_avx512/gcc-14.1.0/python-3.11.9-s6zhes3xdw6n5lx7dy2vkw55bulngxjr/lib/python3.11/contextlib.py", line 158, in __exit__
        self.gen.throw(typ, value, traceback)
      File "/shared/spack/var/spack/environments/heb115/.spack-env/view/lib/python3.11/site-packages/jupyter_server/services/contents/fileio.py", line 227, in perm_to_403
        raise HTTPError(403, "Permission denied: %s" % path) from e
    tornado.web.HTTPError: HTTP 403: Forbidden (Permission denied: 139860/practical_instructions/.ipynb_checkpoints)
[W 2024-10-08 12:01:59.215 ServerApp] 403 GET /node/general-dy-general-cr-2.academic.pcluster/57013/api/contents/139860/practical_instructions/Practical3.ipynb/checkpoints?1728403319049 (9947354d07164bb892e406f7a2a6b64f@10.37.33.205) 34.91ms referer=https://ood.huit.harvard.edu/node/general-dy-general-cr-2.academic.pcluster/57013/lab
[I 2024-10-08 12:01:59.406 ServerApp] Kernel started: 95ba4727-e645-4171-8e59-dfc26c7779de
[I 2024-10-08 12:02:02.792 ServerApp] Connecting to kernel 95ba4727-e645-4171-8e59-dfc26c7779de.
[I 2024-10-08 12:02:02.794 ServerApp] Connecting to kernel 95ba4727-e645-4171-8e59-dfc26c7779de.
[I 2024-10-08 12:02:02.795 ServerApp] Connecting to kernel 95ba4727-e645-4171-8e59-dfc26c7779de.
/shared/home/kal333/ondemand/data/sys/dashboard/batch_connect/sys/ood-jupyterlab-spack/heb115/output/cc1ddcf9-0158-4585-8825-3d80c7bd6961/script.sh: line 36:  4635 Killed                  jupyter lab --config="${CONFIG_FILE}"
Cleaning up...
```

</details>