### PR TITLE
Update spack environmennt for HEB 115

### DIFF
--- a/spack-environment/heb115/spack.yml
+++ b/spack-environment/heb115/spack.yml
@@ -14,7 +14,7 @@ spack:
   - py-numpy
   - py-matplotlib
   - py-scipy
-  - py-geopandas
+  - py-geopandas@0.14.4
   - py-fiona@1.10.1 # Added via spack checksum and spack edit
   view: true
   concretizer:

--- a/spack-environment/heb115/spack.yml
+++ b/spack-environment/heb115/spack.yml
@@ -5,15 +5,17 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - admixtools
-  - bcftools
-  - plink
-  - samtools
+  - admixtools@7.0.2
+  - bcftools@1.19
+  - plink@1.9-beta6.27
+  - samtools@1.19.2
   - py-jupyterlab
-  - py-numpy
   - py-pandas
+  - py-numpy
   - py-matplotlib
   - py-scipy
+  - py-geopandas
+  - py-fiona@1.10.1 # Added via spack checksum and spack edit
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
Updated the spack environment file from the actual installed environment for Fall 2024, which had some additional version specs. Added `py-geopandas`, which required a new version of `py-fiona`, which I was able to get by running `spack checksum py-fiona` to get the checksum values for new versions, then using `spack edit py-fiona` to add them to the python file defining the package. 

There was an install error when setting up `py-geopandas` when the `py-fiona` dependency tried to install. The symptoms were the same as [an issue reported in the Fiona repository](https://github.com/Toblerity/Fiona/issues/1427) which was reported fixed in v1.10, which is why I had to add that version to spack.

Similarly, when trying to use `geopandas`, it had an error that required updating it to `v0.14.4`, which had to be added as an available version to spack using the same method as for the Fiona install.