### PR TITLE
Fix a missing option in form for PHYSCI 12A

### DIFF
--- a/local/physci12a.yml.erb
+++ b/local/physci12a.yml.erb
@@ -80,6 +80,15 @@ attributes:
     max: 12  # 12 hours max
     step: 1
 
+  # For this checkbox, a checked value is "1" as a string, and an unchecked
+  # value is "0" as a string. It's used to determine whether or not to redirect
+  # the ipynb_checkpoints folder to /tmp, functionally disabling checkpoints.
+  disable_checkpoints:
+    widget: "check_box"
+    label: "Disable Checkpoints"
+    help: |
+      Redirects `.ipynb_checkpoints` to `/tmp`, so checkpoints are not persistent. Select this option if you do not want checkpoint folders to appear, or if the checkpoints are causing problems.
+
   # Any extra command line arguments to feed to the `jupyter notebook ...`
   # command that launches the Jupyter notebook within the batch job
   extra_jupyter_args: ""
@@ -99,3 +108,4 @@ form:
   - extra_jupyter_args
   - bc_num_hours
   - custom_num_cores
+  - disable_checkpoints


### PR DESCRIPTION
# Overview

The form in the `locals` folder for PHYSCI 12A was missing the option for disabling `.ipynb-checkpoints`, which created an issue launching the app.

The behavior reported by a user was being unable to launch a notebook session, with the following error message:

```
undefined method `disable_checkpoints' for #<BatchConnect::SessionContext:0x0000710e14c52e00...
```

This was confirmed in testing.

# Changes

This PR adds that option to the form in the `locals` folder for PHYSCI 12A

# Notes

A future improvement would be to include a failsafe state for the app if the option is not defined. This would have to happen in Ruby code, where the `disable_checkpoints` variable from the form is referenced.
